### PR TITLE
Update padding to handle sizes greater than 32 bytes,

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -93,21 +93,17 @@ std::string utils::padTo32Bytes(const std::string& input, utils::PaddingDirectio
         output = output.substr(2);  // remove "0x" prefix for now
     }
 
-    if(output.size() > targetSize) {
-        throw std::runtime_error("Input size is greater than target size");
+    // Calculate padding size based on targetSize
+    size_t nextMultiple = (output.size() + targetSize - 1) / targetSize * targetSize;
+    size_t paddingSize = nextMultiple - output.size();
+    std::string padding(paddingSize, '0');
+     
+    if(direction == utils::PaddingDirection::LEFT) {
+        output = padding + output;
     }
-    else if(output.size() < targetSize) {
-        size_t paddingSize = targetSize - input.size();
-        //std::string padding(paddingSize, 0);
-        std::string padding(paddingSize, '0');
-
-        if(direction == utils::PaddingDirection::LEFT) {
-            output = padding + output;
-        }
-        else {
-            output += padding;
-        }
-    }
+    else {
+        output += padding;
+    }    
 
     // If input started with "0x", add it back
     if (has0xPrefix) {


### PR DESCRIPTION
Previously the padding would fail if a string was passed in with more than 64 characters, now it will pad out to a multiple of 64 characters (32 bytes) if the input is larger