### PR TITLE
Remove boost from build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ endif()
 
 # Find all headers and implementation files
 include(cmake/SourcesAndHeaders.cmake)
-
-find_package(Boost 1.62 QUIET REQUIRED COMPONENTS system thread serialization program_options)
 if(${PROJECT_NAME}_ENABLE_CRYPTO_LIBRARY)
     add_subdirectory(src/crypto)
 endif()

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ C++ library for communicating with Ethereum
 
 ### Prerequisites
 ```
-apt install cmake build-essential libboost-all-dev libssl-dev libcurl4-openssl-dev libsodium-dev
+apt install cmake build-essential libssl-dev libcurl4-openssl-dev libsodium-dev
 ```
 
 ### Building from Source

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -52,7 +52,6 @@ add_library(cncrypto
 
 target_link_libraries(cncrypto
   PUBLIC
-    Boost::thread
     sodium
   PRIVATE
     )


### PR DESCRIPTION
The boost components listed in the CMakeLists.txt is not required as it is not used by the library. We have one usage of boost for aligned_alloc, however, aligned_alloc is supported in C++17 so we defer to that hence removing boost from the build.