### PR TITLE
Support MSYS2 build, fix Linux build and document build steps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ endif()
 
 # Find all headers and implementation files
 include(cmake/SourcesAndHeaders.cmake)
-
-find_package(Boost 1.62 QUIET REQUIRED COMPONENTS system thread serialization program_options)
 if(${PROJECT_NAME}_ENABLE_CRYPTO_LIBRARY)
     add_subdirectory(src/crypto)
 endif()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ apt install cmake build-essential libssl-dev libcurl4-openssl-dev
 
 # Build
 cmake -B build -S .
-cmake --build build/msys --parallel --verbose
+cmake --build build --parallel --verbose
 ```
 
 **Windows via MSYS2 (MinGW, UCRT64, e.t.c)**

--- a/README.md
+++ b/README.md
@@ -4,26 +4,37 @@ C++ library for communicating with Ethereum.
 
 ## Building
 
-### Prerequisites
+Clone the repository `git clone --recursive` or if already cloned, `git
+submodule update --init --recursive` at the root to ensure all source code is
+retrieved.
+
+Then run the following commands from the root of this repository:
+
+**Linux**
 
 ```
+# Install dependencies
 apt install cmake build-essential libssl-dev libcurl4-openssl-dev
+
+# Build
+cmake -B build -S .
+cmake --build build/msys --parallel --verbose
 ```
 
-### Building from Source
-
-Clone the repository as usual, including submodules (either by passing
-`--recurse-submodules` to `git clone`, or else running `git submodule update
---init --recursive` the top-level project directory).
-
-To compile the library run the following commands from the project source
-directory:
+**Windows via MSYS2 (MinGW, UCRT64, e.t.c)**
 
 ```
-mkdir -p build
-cd build
-cmake ..
-make -j8  # Tweak as needed for the desired build parallelism
+# Update pacman and install dependencies
+pacman -Syuu # Terminal may prompt to restart before proceeding
+pacman -S git base-devel libargp-devel cmake gcc libcurl-devel gmp-devel autoconf automake libtool
+
+# MSYS packages libargp with a .dll suffix which breaks rlpvalue's autotool
+# script so we patch it up
+ln -s /usr/lib/libargp.dll.a /usr/lib/libargp.a
+
+# Build
+cmake -B build -S .
+cmake --build build --parallel --verbose
 ```
 
 Various options can be added to the `cmake ..` line; some common options are:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Ethyl
-C++ library for communicating with Ethereum
+
+C++ library for communicating with Ethereum.
 
 ## Building
 
 ### Prerequisites
+
 ```
-apt install cmake build-essential libssl-dev libcurl4-openssl-dev libsodium-dev
+apt install cmake build-essential libssl-dev libcurl4-openssl-dev
 ```
 
 ### Building from Source
 
-Clone the repository as usual, including submodules (either by passing `--recurse-submodules` to
-`git clone`, or else running `git submodule update --init --recursive` the top-level project
-directory).
+Clone the repository as usual, including submodules (either by passing
+`--recurse-submodules` to `git clone`, or else running `git submodule update
+--init --recursive` the top-level project directory).
 
-To compile the library run the following commands from the project source directory:
+To compile the library run the following commands from the project source
+directory:
 
 ```
 mkdir -p build
@@ -28,6 +31,8 @@ Various options can be added to the `cmake ..` line; some common options are:
 
 ## Testing
 
-Unit tests use [Catch2](https://github.com/catchorg/Catch2) as a formal unit-test framework. Unit
-tests are built by default as part of the standard CMake build logic (unless being built as a
-subdirectory of another CMake project) and can be invoked through the `make test` or running the test binaries build in `build/tests`.
+Unit tests use [Catch2](https://github.com/catchorg/Catch2) as a formal
+unit-test framework. Unit tests are built by default as part of the standard
+CMake build logic (unless being built as a subdirectory of another CMake
+project) and can be invoked through the `make test` or running the test binaries
+build in `build/tests`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ C++ library for communicating with Ethereum
 
 ### Prerequisites
 ```
-apt install cmake build-essential libboost-all-dev libssl-dev libcurl4-openssl-dev libsodium-dev
+apt install cmake build-essential libssl-dev libcurl4-openssl-dev libsodium-dev
 ```
 
 ### Building from Source

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -47,7 +47,6 @@ function(set_project_warnings project_name)
       -Wnon-virtual-dtor # warn the user if a class with virtual functions has a
                          # non-virtual destructor. This helps catch hard to
                          # track down memory errors
-      -Wold-style-cast # warn for c-style casts
       -Wcast-align     # warn for potential performance problem casts
       -Wunused         # warn on anything being unused
       -Woverloaded-virtual # warn if you overload (not override) a virtual

--- a/cmake/rlpvalue-001-infint-missing-limits-h.patch
+++ b/cmake/rlpvalue-001-infint-missing-limits-h.patch
@@ -1,0 +1,12 @@
+diff --git a/src/InfInt.h b/src/InfInt.h
+index 14ff215..60bac4f 100644
+--- a/src/InfInt.h
++++ b/src/InfInt.h
+@@ -40,6 +40,7 @@
+ #include <sstream>
+ #include <iomanip>
+ #include <climits>
++#include <limits>
+ 
+ //#include <limits.h>
+ //#include <stdlib.h>

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(NOT TARGET cpr)
-    set(CPR_USE_SYSTEM_CURL ON CACHE BOOL "" FORCE)
+    set(CPR_USE_SYSTEM_CURL ON CACHE BOOL "")
     add_subdirectory(cpr)
 endif()
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,32 +18,37 @@ if(NOT TARGET Catch2)
     add_subdirectory(Catch2)
 endif()
 
-# RLPValue is built using autotools
+
+#
+# rlpvalue is built using autotools
+#
 include(ExternalProject)
-
-set(RLP_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rlpvalue)
-set(RLP_BIN ${CMAKE_CURRENT_BINARY_DIR}/librlpvalue)
-set(RLP_SHARED_LIB ${RLP_BIN}/lib/librlpvalue.so)
-set(RLP_INCLUDES ${RLP_BIN}/include)
-
+set(RLP_DIR         ${CMAKE_CURRENT_SOURCE_DIR}/rlpvalue)
+set(RLP_BIN         ${CMAKE_CURRENT_BINARY_DIR}/librlpvalue)
+set(RLP_STATIC_LIB  ${RLP_BIN}/lib/librlpvalue.a)
+set(RLP_INCLUDES    ${RLP_BIN}/include)
 file(MAKE_DIRECTORY ${RLP_INCLUDES})
 
+# NOTE: rlpvalue includes a sub-project, univalue which it configures from the
+# top level script. Passing in the `--prefix` at the top-level does not
+# propagate down to the bottom level causing `make install` to install to the
+# system level prefix.
+#
+# We override this by specifying prefix at the last step ensuring that both
+# `rlpvalue` and `univalue` are installed to the same prefix.
 ExternalProject_Add(
     librlpvalue
-    PREFIX ${RLP_BIN}
-    SOURCE_DIR ${RLP_DIR}
-    DOWNLOAD_COMMAND cd ${RLP_DIR} && git clean -dfX && ${RLP_DIR}/autogen.sh
-    CONFIGURE_COMMAND ${RLP_DIR}/configure --srcdir=${RLP_DIR} --prefix=${RLP_BIN} --enable-shared=yes --disable-static
-    BUILD_COMMAND make
-    INSTALL_COMMAND make install
-    BUILD_BYPRODUCTS ${RLP_SHARED_LIB}
+    PREFIX            ${RLP_BIN}
+    SOURCE_DIR        ${RLP_DIR}
+    DOWNLOAD_COMMAND  cd ${RLP_DIR} && git clean -dfX
+    CONFIGURE_COMMAND bash -c ${RLP_DIR}/autogen.sh && bash -c ${RLP_DIR}/configure --srcdir=${RLP_DIR} --disable-shared --enable-static=yes
+    BUILD_COMMAND     make
+    INSTALL_COMMAND   make install prefix=${RLP_BIN}
+    BUILD_BYPRODUCTS  ${RLP_STATIC_LIB} ${RLP_BIN}/lib/libunivalue.a
 )
-
-add_library(rlpvalue SHARED IMPORTED GLOBAL)
-
-add_dependencies(rlpvalue librlpvalue)
-
-set_target_properties(rlpvalue PROPERTIES IMPORTED_LOCATION ${RLP_SHARED_LIB})
+add_library          (rlpvalue STATIC IMPORTED GLOBAL)
+add_dependencies     (rlpvalue librlpvalue)
+set_target_properties(rlpvalue PROPERTIES IMPORTED_LOCATION ${RLP_STATIC_LIB})
 set_target_properties(rlpvalue PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${RLP_INCLUDES})
 
 if(NOT TARGET nlohmann_json)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,8 +1,14 @@
+#
+# CPR
+#
 if(NOT TARGET cpr)
     set(CPR_USE_SYSTEM_CURL ON CACHE BOOL "")
     add_subdirectory(cpr)
 endif()
 
+#
+# SECP256k1
+#
 if(NOT TARGET secp256k1)
     set(SECP256K1_ENABLE_MODULE_RECOVERY ON CACHE BOOL "" FORCE)
     set(SECP256K1_VALGRIND OFF CACHE BOOL "" FORCE)
@@ -14,10 +20,12 @@ if(NOT TARGET secp256k1)
     add_subdirectory(secp256k1)
 endif()
 
+#
+# Catch2
+#
 if(NOT TARGET Catch2)
     add_subdirectory(Catch2)
 endif()
-
 
 #
 # rlpvalue is built using autotools
@@ -51,12 +59,18 @@ add_dependencies     (rlpvalue librlpvalue)
 set_target_properties(rlpvalue PROPERTIES IMPORTED_LOCATION ${RLP_STATIC_LIB})
 set_target_properties(rlpvalue PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${RLP_INCLUDES})
 
+#
+# nlohmann_json
+#
 if(NOT TARGET nlohmann_json)
     set(JSON_BuildTests OFF CACHE INTERNAL "")
     set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
     add_subdirectory(json EXCLUDE_FROM_ALL)
 endif()
 
+#
+# GMP
+#
 find_library(gmp gmp)
 if(NOT gmp)
   message(FATAL_ERROR "gmp not found")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -50,6 +50,8 @@ ExternalProject_Add(
     SOURCE_DIR        ${RLP_DIR}
     DOWNLOAD_COMMAND  cd ${RLP_DIR} && git clean -dfX
     CONFIGURE_COMMAND bash -c ${RLP_DIR}/autogen.sh && bash -c ${RLP_DIR}/configure --srcdir=${RLP_DIR} --disable-shared --enable-static=yes
+    PATCH_COMMAND     git checkout -- src/InfInt.h &&
+                      git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/rlpvalue-001-infint-missing-limits-h.patch
     BUILD_COMMAND     make
     INSTALL_COMMAND   make install prefix=${RLP_BIN}
     BUILD_BYPRODUCTS  ${RLP_STATIC_LIB} ${RLP_BIN}/lib/libunivalue.a

--- a/include/ethyl/ecdsa_util.h
+++ b/include/ethyl/ecdsa_util.h
@@ -52,7 +52,7 @@
 #elif defined(__linux__) || defined(__FreeBSD__)
     /* If `getrandom(2)` is not available you should fallback to /dev/urandom */
     ssize_t res = getrandom(data, size, 0);
-    if (res < 0 || static_cast<size_t>(res) != size ) {
+    if (res < 0 || (size_t)res != size ) {
         return 0;
     } else {
         return 1;

--- a/include/ethyl/ecdsa_util.h
+++ b/include/ethyl/ecdsa_util.h
@@ -37,7 +37,7 @@
 #include <stddef.h>
 #include <limits.h>
 #include <stdio.h>
-#include <cstring>
+#include <string.h>
 
 
 /* Returns 1 on success, and 0 on failure. */

--- a/include/ethyl/ecdsa_util.h
+++ b/include/ethyl/ecdsa_util.h
@@ -16,7 +16,7 @@
  * Windows -> `BCryptGenRandom`(`bcrypt.h`). https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
  */
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__)
 /*
  * The defined WIN32_NO_STATUS macro disables return code definitions in
  * windows.h, which avoids "macro redefinition" MSVC warnings in ntstatus.h.
@@ -42,8 +42,8 @@
 
 /* Returns 1 on success, and 0 on failure. */
 [[maybe_unused]] static int fill_random(unsigned char* data, size_t size) {
-#if defined(_WIN32)
-    NTSTATUS res = BCryptGenRandom(NULL, data, size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+#if defined(_WIN32) || defined(__CYGWIN__)
+    NTSTATUS res = BCryptGenRandom(NULL, data, (ULONG)size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
     if (res != STATUS_SUCCESS || size > ULONG_MAX) {
         return 0;
     } else {
@@ -79,13 +79,13 @@
     printf("\n");
 }
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__CYGWIN__)
 // For SecureZeroMemory
 #include <Windows.h>
 #endif
 /* Cleanses memory to prevent leaking sensitive info. Won't be optimized out. */
 [[maybe_unused]] static void secure_erase(void *ptr, size_t len) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__CYGWIN__)
     /* SecureZeroMemory is guaranteed not to be optimized out by MSVC. */
     SecureZeroMemory(ptr, len);
 #elif defined(__GNUC__)

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -50,6 +50,10 @@ add_library(cncrypto
   cn_turtle_hash.c
   tree-hash.c)
 
+if (WIN32 OR CYGWIN)
+    target_link_libraries(cncrypto PUBLIC bcrypt)
+endif()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -50,12 +50,6 @@ add_library(cncrypto
   cn_turtle_hash.c
   tree-hash.c)
 
-target_link_libraries(cncrypto
-  PUBLIC
-    sodium
-  PRIVATE
-    )
-
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -52,7 +52,6 @@ add_library(cncrypto
 
 target_link_libraries(cncrypto
   PUBLIC
-    Boost::thread
     sodium
   PRIVATE
     )

--- a/src/crypto/blake256.c
+++ b/src/crypto/blake256.c
@@ -38,6 +38,7 @@
  */
 
 #include "blake256.h"
+#include "../../include/ethyl/ecdsa_util.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -296,7 +297,7 @@ void hmac_blake256_init(hmac_state* S, const uint8_t* _key, uint64_t keylen) {
     }
     blake256_update(&S->outer, pad, 512);
 
-    memwipe(keyhash, sizeof(keyhash));
+    secure_erase(keyhash, sizeof(keyhash));
 }
 
 // keylen = number of bytes
@@ -326,7 +327,7 @@ void hmac_blake224_init(hmac_state* S, const uint8_t* _key, uint64_t keylen) {
     }
     blake224_update(&S->outer, pad, 512);
 
-    memwipe(keyhash, sizeof(keyhash));
+    secure_erase(keyhash, sizeof(keyhash));
 }
 
 // datalen = number of bits
@@ -346,7 +347,7 @@ void hmac_blake256_final(hmac_state* S, uint8_t* digest) {
     blake256_final(&S->inner, ihash);
     blake256_update(&S->outer, ihash, 256);
     blake256_final(&S->outer, digest);
-    memwipe(ihash, sizeof(ihash));
+    secure_erase(ihash, sizeof(ihash));
 }
 
 void hmac_blake224_final(hmac_state* S, uint8_t* digest) {
@@ -354,7 +355,7 @@ void hmac_blake224_final(hmac_state* S, uint8_t* digest) {
     blake224_final(&S->inner, ihash);
     blake224_update(&S->outer, ihash, 224);
     blake224_final(&S->outer, digest);
-    memwipe(ihash, sizeof(ihash));
+    secure_erase(ihash, sizeof(ihash));
 }
 
 // keylen = number of bytes; inlen = number of bytes

--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -42,7 +42,7 @@
 // allocations of any kind. Instead, MS CRT provides _aligned_malloc (to be
 // freed with _aligned_free).
 // https://en.cppreference.com/w/cpp/memory/c/aligned_alloc
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW64__)
     #include <malloc.h>
     #define CNHH_ALIGNED_ALLOC(align, size) _aligned_malloc(size, align)
     #define CNHH_ALIGNED_FREE(ptr) _aligned_free(ptr)

--- a/src/crypto/cn_turtle_hash-amd64.inl
+++ b/src/crypto/cn_turtle_hash-amd64.inl
@@ -2,7 +2,7 @@
 // before actually calling any AES code, and otherwise fall back to more portable code.
 
 #include <emmintrin.h>
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
 #  include <intrin.h>
 #  include <windows.h>
 #else
@@ -282,7 +282,7 @@ STATIC INLINE void aes_pseudo_round_xor(const uint8_t *in, uint8_t *out,
     }
 }
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
 BOOL SetLockPagesPrivilege(HANDLE hProcess, BOOL bEnable)
 {
   struct
@@ -330,7 +330,7 @@ void slow_hash_allocate_state(uint32_t page_size)
     if(hp_state != NULL)
         return;
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
     SetLockPagesPrivilege(GetCurrentProcess(), TRUE);
     hp_state = (uint8_t *) VirtualAlloc(hp_state, page_size, MEM_LARGE_PAGES |
                                         MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
@@ -367,7 +367,7 @@ void slow_hash_free_state(uint32_t page_size)
         free(hp_state);
     else
     {
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
         VirtualFree(hp_state, 0, MEM_RELEASE);
 #else
         munmap(hp_state, page_size);

--- a/src/crypto/hmac-keccak.c
+++ b/src/crypto/hmac-keccak.c
@@ -27,6 +27,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "hmac-keccak.h"
+#include "../../include/ethyl/ecdsa_util.h"
 
 #define KECCAK_BLOCKLEN 136
 #define HASH_SIZE 32
@@ -57,7 +58,7 @@ void hmac_keccak_init(hmac_keccak_state* S, const uint8_t* _key, size_t keylen) 
     }
     keccak_update(&S->outer, pad, KECCAK_BLOCKLEN);
 
-    memwipe(keyhash, HASH_SIZE);
+    secure_erase(keyhash, HASH_SIZE);
 }
 
 void hmac_keccak_update(hmac_keccak_state* S, const uint8_t* data, size_t datalen) {
@@ -69,7 +70,7 @@ void hmac_keccak_finish(hmac_keccak_state* S, uint8_t* digest) {
     keccak_finish(&S->inner, ihash);
     keccak_update(&S->outer, ihash, HASH_SIZE);
     keccak_finish(&S->outer, digest);
-    memwipe(ihash, HASH_SIZE);
+    secure_erase(ihash, HASH_SIZE);
 }
 
 void hmac_keccak_hash(


### PR DESCRIPTION
This PR goes on-top of https://github.com/oxen-io/ethyl/pull/9 and gets the library compiling on Windows via msys (and derivatives) based toolchain.

- Fix compilation failure with C++ style cast used in a header file that is shared between C and C++ codebases.
- Compile rlpvalue statically for reliability and simplicity
- Substitute `memwipe` which is missing but was originally from `epee` with `secure_erase` which is provided from `ecdsa_util.h` to the same effect
- Remove libsodium which is not currently used in the library
- Add necessary compile defines for recognising the cygwin based toolchain
- Fix rlpvalue using `std::numeric_limits` without including `<limits>`

