### PR TITLE
New supporting functions for eth-sn-contracts

### DIFF
--- a/include/ethyl/provider.hpp
+++ b/include/ethyl/provider.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <optional>
 #include <chrono>
 
@@ -38,9 +39,10 @@ public:
     void connectToNetwork();
     void disconnectFromNetwork();
 
-    uint64_t getTransactionCount(const std::string& address, const std::string& blockTag);
-    std::string callReadFunction(const ReadCallData& callData, uint64_t blockNumberInt);
-    std::string callReadFunction(const ReadCallData& callData, const std::string& blockNumber = "latest");
+    uint64_t       getTransactionCount(const std::string& address, const std::string& blockTag);
+    nlohmann::json callReadFunctionJSON(const ReadCallData& callData, std::string_view blockNumber = "latest");
+    std::string    callReadFunction(const ReadCallData& callData, std::string_view blockNumber = "latest");
+    std::string    callReadFunction(const ReadCallData& callData, uint64_t blockNumberInt);
 
     uint32_t getNetworkChainId();
     std::string evm_snapshot();

--- a/include/ethyl/signer.hpp
+++ b/include/ethyl/signer.hpp
@@ -24,7 +24,8 @@ public:
 
     // Returns <Pubkey, Seckey>
     std::pair<std::vector<unsigned char>, std::vector<unsigned char>> generate_key_pair();
-    std::string addressFromPrivateKey(const std::vector<unsigned char>& seckey);
+    std::array<unsigned char, 20>                                     secretKeyToAddress(const std::vector<unsigned char>& seckey);
+    std::string                                                       secretKeyToAddressString(const std::vector<unsigned char>& seckey);
 
     std::vector<unsigned char> sign(const std::array<unsigned char, 32>& hash, const std::vector<unsigned char>& seckey);
     std::vector<unsigned char> sign(const std::string& hash, const std::vector<unsigned char>& seckey);

--- a/include/ethyl/utils.hpp
+++ b/include/ethyl/utils.hpp
@@ -45,7 +45,7 @@ namespace utils
 
     std::string getFunctionSignature(const std::string& function);
 
-    std::string padToNBytes(const std::string& input, size_t byte_count, PaddingDirection direction = PaddingDirection::LEFT);
+    std::string padToNBytes(const std::string& input, size_t byteCount, PaddingDirection direction = PaddingDirection::LEFT);
     std::string padTo8Bytes(const std::string& input, PaddingDirection direction = PaddingDirection::LEFT);
     std::string padTo32Bytes(const std::string& input, PaddingDirection direction = PaddingDirection::LEFT);
 

--- a/include/ethyl/utils.hpp
+++ b/include/ethyl/utils.hpp
@@ -34,12 +34,13 @@ namespace utils
         return oss.str();
     }
 
-    std::string decimalToHex(uint64_t decimal);
+    std::string      decimalToHex(uint64_t decimal);
+    std::string_view trimPrefix(std::string_view src, std::string_view prefix);
+    std::string_view trimLeadingZeros(std::string_view src);
 
-    std::vector<unsigned char> fromHexString(std::string hex_str);
-    uint64_t fromHexStringToUint64(std::string hex_str);
-
-    std::array<unsigned char, 32> fromHexString32Byte(std::string hex_str);
+    std::vector<unsigned char>    fromHexString(std::string_view hexStr);
+    uint64_t                      fromHexStringToUint64(std::string_view hexStr);
+    std::array<unsigned char, 32> fromHexString32Byte(std::string_view hexStr);
 
     std::array<unsigned char, 32> hash(std::string in);
 

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -66,7 +66,13 @@ nlohmann::json Provider::callReadFunctionJSON(const ReadCallData& callData, std:
         }
     }
 
-    throw std::runtime_error("Unable to get the result of the function call");
+    std::stringstream stream;
+    stream << "'eth_call' invoked on node for block '" << blockNumber
+           << "' to '" << callData.contractAddress
+           << "' with data payload '" << callData.data
+           << "' however it returned a response that does not have a result: "
+           << response.text;
+    throw std::runtime_error(stream.str());
 }
 
 std::string Provider::callReadFunction(const ReadCallData& callData, std::string_view blockNumber) {

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -48,30 +48,38 @@ cpr::Response Provider::makeJsonRpcRequest(const std::string& method, const nloh
     return session.Post();
 }
 
-std::string Provider::callReadFunction(const ReadCallData& callData, uint64_t blockNumberInt) {
-    std::stringstream stream;
-    stream << "0x" << std::hex << blockNumberInt;  // Convert uint64_t to hex string
-    std::string blockNumberHex = stream.str();
-    
-    return callReadFunction(callData, blockNumberHex);  // Call the original function
-}
+nlohmann::json Provider::callReadFunctionJSON(const ReadCallData& callData, std::string_view blockNumber) {
+    nlohmann::json result = {};
 
-std::string Provider::callReadFunction(const ReadCallData& callData, const std::string& blockNumber) {
     // Prepare the params for the eth_call request
-    nlohmann::json params = nlohmann::json::array();
-    params[0]["to"] = callData.contractAddress;
-    params[0]["data"] = callData.data;
-    params[1] = blockNumber; // use the provided block number or default to "latest"
+    nlohmann::json params  = nlohmann::json::array();
+    params[0]["to"]        = callData.contractAddress;
+    params[0]["data"]      = callData.data;
+    params[1]              = blockNumber; // use the provided block number or default to "latest"
     cpr::Response response = makeJsonRpcRequest("eth_call", params);
 
     if (response.status_code == 200) {
         nlohmann::json responseJson = nlohmann::json::parse(response.text);
         if (!responseJson["result"].is_null()) {
-            return responseJson["result"];
+            result = responseJson["result"];
+            return result;
         }
     }
 
     throw std::runtime_error("Unable to get the result of the function call");
+}
+
+std::string Provider::callReadFunction(const ReadCallData& callData, std::string_view blockNumber) {
+    std::string result = callReadFunctionJSON(callData, blockNumber);
+    return result;
+}
+
+std::string Provider::callReadFunction(const ReadCallData& callData, uint64_t blockNumberInt) {
+    std::stringstream stream;
+    stream << "0x" << std::hex << blockNumberInt; // Convert uint64_t to hex string
+    std::string blockNumberHex = stream.str();
+    std::string result         = callReadFunctionJSON(callData, blockNumberHex);
+    return result;
 }
 
 uint32_t Provider::getNetworkChainId() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -81,7 +81,7 @@ std::string utils::getFunctionSignature(const std::string& function) {
     return "0x" + hashHex.substr(0, 8);
 }
 
-std::string utils::padToNBytes(const std::string& input, size_t byte_count, utils::PaddingDirection direction) {
+std::string utils::padToNBytes(const std::string& input, size_t byteCount, utils::PaddingDirection direction) {
     std::string output = input;
     bool has0xPrefix = false;
 
@@ -92,20 +92,21 @@ std::string utils::padToNBytes(const std::string& input, size_t byte_count, util
     }
 
     // Calculate padding size based on byteCount * 2 (since each byte is represented by 2 hex characters)
-    size_t targetHexStringSize = byte_count * 2;
-    size_t nextMultiple = (output.size() + targetHexStringSize - 1) / targetHexStringSize * targetHexStringSize;
-    size_t paddingSize = nextMultiple - output.size();
-    std::string padding(paddingSize, '0');
+    const size_t targetHexStringSize   = byteCount * 2;
+    const size_t startingSize          = std::max(output.size(), static_cast<size_t>(1)); // Size is atleast 1 element such that we handle when output.size == 0
+    const size_t startingSizeRoundedUp = startingSize + (targetHexStringSize - 1);
+    const size_t nextMultiple          = /*floor*/ (startingSizeRoundedUp / targetHexStringSize) * targetHexStringSize;
+    const size_t paddingSize           = nextMultiple - output.size();
 
     if (direction == PaddingDirection::LEFT) {
-        output = padding + output;
+        output.insert(0, paddingSize, '0');
     } else {
-        output += padding;
+        output.append(paddingSize, '0');
     }
 
     // If input started with "0x", add it back
     if (has0xPrefix) {
-        output = "0x" + output;
+        output.insert(0, "0x");
     }
 
     return output;

--- a/test/src/ethereum_client.cpp
+++ b/test/src/ethereum_client.cpp
@@ -38,7 +38,7 @@ TEST_CASE( "SigningTest", "[signer]" ) {
 TEST_CASE( "Get address from private key", "[signer]" ) {
     std::vector<unsigned char> seckey = utils::fromHexString(std::string(PRIVATE_KEY));
     Signer signer;
-    std::string created_address = signer.addressFromPrivateKey(seckey);
+    std::string created_address = signer.secretKeyToAddressString(seckey);
     REQUIRE( created_address == ADDRESS );
 }
 


### PR DESCRIPTION
Various tid-bits and fixes for new functionality in the eth-sn-contracts tests

- `Provider::callReadFunction` now thunks into `Provider::callReadFunctionJSON`, the latter which returns the original `nlohmann::json` object which is more optimal because it allows grabbing the `result` string by reference saving an allocation.
- Rename `addressFromPrivateKey` to `secretKeyToAddress[String]` and add a version that preserves the binary representation of the address.
- Update fromHexString and co. to use string_views. This means APIs can take string literals without requiring an allocation, but also allows slices of strings. Some of the C++ hex APIs don't accept string_view and would require an allocation to reconvert it back. I've avoided this by introducing our own hex conversion function.
- Add some helper string trimming functions
- Fix padToNBytes not rounding a 0-sized string to N and avoid various allocations in the function by reusing the string object we construct.