### PR TITLE
Support backup providers in `ethyl::Provider`

### DIFF
--- a/include/ethyl/provider.hpp
+++ b/include/ethyl/provider.hpp
@@ -37,7 +37,6 @@ class Provider {
     std::mutex mutex;
 public:
     Provider(std::string name, std::string url);
-    ~Provider();
 
     void connectToNetwork();
     void disconnectFromNetwork();

--- a/include/ethyl/provider.hpp
+++ b/include/ethyl/provider.hpp
@@ -16,6 +16,8 @@
 
 using namespace std::literals;
 
+namespace ethyl
+{
 struct ReadCallData {
     std::string contractAddress;
     std::string data;
@@ -74,4 +76,4 @@ public:
 private:
     cpr::Response makeJsonRpcRequest(std::string_view method, const nlohmann::json& params);
 };
-
+}; // namespace ethyl

--- a/include/ethyl/provider.hpp
+++ b/include/ethyl/provider.hpp
@@ -32,12 +32,7 @@ struct FeeData {
         : gasPrice(_gasPrice), maxFeePerGas(_maxFeePerGas), maxPriorityFeePerGas(_maxPriorityFeePerGas) {}
 };
 
-class Provider {
-    std::string clientName;
-    cpr::Url url;
-    cpr::Session session;
-    std::mutex mutex;
-public:
+struct Provider {
     Provider(std::string name, std::string url);
 
     void connectToNetwork();
@@ -75,5 +70,10 @@ public:
 
 private:
     cpr::Response makeJsonRpcRequest(std::string_view method, const nlohmann::json& params);
+
+    std::string clientName;
+    cpr::Url url;
+    cpr::Session session;
+    std::mutex mutex;
 };
 }; // namespace ethyl

--- a/include/ethyl/signer.hpp
+++ b/include/ethyl/signer.hpp
@@ -16,7 +16,6 @@ namespace ethyl
 class Signer {
 private:
     secp256k1_context* ctx;
-    std::shared_ptr<Provider> provider;
 
     uint64_t maxPriorityFeePerGas = 0;
     uint64_t maxFeePerGas = 0;
@@ -24,7 +23,6 @@ private:
 
 public:
     Signer();
-    Signer(const std::shared_ptr<Provider>& client);
     ~Signer();
 
     // Returns <Pubkey, Seckey>
@@ -36,18 +34,12 @@ public:
     std::vector<unsigned char> sign(std::string_view hash, std::span<const unsigned char> seckey);
 
     // Client usage methods
-    bool hasProvider() const { return static_cast<bool>(provider); }
-    std::shared_ptr<Provider> getProvider() { return provider; }
-
-
-    std::vector<unsigned char> signMessage(std::string_view message, std::span<const unsigned char> seckey);
-    std::string signTransaction(Transaction& tx, std::span<const unsigned char> seckey);
+    std::vector<unsigned char> signMessage(const std::string& message, const std::vector<unsigned char>& seckey);
+    std::string signTransaction(Transaction& tx, const std::vector<unsigned char>& seckey);
 
     void populateTransaction(Transaction& tx, std::string sender_address);
     std::string sendTransaction(Transaction& tx, std::span<const unsigned char> seckey);
 
-
-private:
-    void initContext();
+    Provider provider;
 };
 }; // namespace ethyl

--- a/include/ethyl/signer.hpp
+++ b/include/ethyl/signer.hpp
@@ -11,6 +11,8 @@
 
 typedef struct secp256k1_context_struct secp256k1_context; // forward decl
 
+namespace ethyl
+{
 class Signer {
 private:
     secp256k1_context* ctx;
@@ -47,7 +49,5 @@ public:
 
 private:
     void initContext();
-
-// END
 };
-
+}; // namespace ethyl

--- a/include/ethyl/signer.hpp
+++ b/include/ethyl/signer.hpp
@@ -34,8 +34,8 @@ public:
     std::vector<unsigned char> sign(std::string_view hash, std::span<const unsigned char> seckey);
 
     // Client usage methods
-    std::vector<unsigned char> signMessage(const std::string& message, const std::vector<unsigned char>& seckey);
-    std::string signTransaction(Transaction& tx, const std::vector<unsigned char>& seckey);
+    std::vector<unsigned char> signMessage(std::string_view message, std::span<const unsigned char> seckey);
+    std::string signTransaction(Transaction& tx, std::span<const unsigned char> seckey);
 
     void populateTransaction(Transaction& tx, std::string sender_address);
     std::string sendTransaction(Transaction& tx, std::span<const unsigned char> seckey);

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -16,7 +16,8 @@
 
 #include <gmpxx.h>
 
-
+namespace ethyl
+{
 Provider::Provider(std::string name, std::string url)
     : clientName{std::move(name)}, url{std::move(url)} {
     // Initialize client
@@ -517,3 +518,4 @@ FeeData Provider::getFeeData() {
 
     return FeeData(gasPrice, maxFeePerGas, maxPriorityFeePerGas);
 }
+}; // namespace ethyl

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -18,18 +18,12 @@
 
 namespace ethyl
 {
-<<<<<<< HEAD
-Provider::Provider(std::string name, std::string url)
-    : clientName{std::move(name)}, url{std::move(url)} {
-    // Initialize client
-=======
 bool Provider::addClient(std::string name, std::string url) {
     bool result = url.size();
     if (result) {
         clients.emplace_back(Client{std::move(name), std::move(url)});
     }
     return result;
->>>>>>> 589a2a9 (Support multiple RPC backends/backup clients)
 }
 
 bool Provider::connectToNetwork() {
@@ -49,19 +43,15 @@ void Provider::disconnectFromNetwork() {
     std::cout << "Disconnected from the Ethereum network.\n";
 }
 
-<<<<<<< HEAD
-cpr::Response Provider::makeJsonRpcRequest(std::string_view method, const nlohmann::json& params) {
-    if (url.str() == "")
-        throw std::runtime_error("No URL provided to provider");
-=======
-cpr::Response Provider::makeJsonRpcRequest(const std::string& method, const nlohmann::json& params, std::optional<std::chrono::milliseconds> timeout) {
+cpr::Response Provider::makeJsonRpcRequest(std::string_view method,
+                                           const nlohmann::json& params,
+                                           std::optional<std::chrono::milliseconds> timeout) {
     if (clients.empty()) {
       throw std::runtime_error(
           "No clients were set for the provider. Ensure that a client was "
           "added to the provider before issuing a request.");
     }
 
->>>>>>> 589a2a9 (Support multiple RPC backends/backup clients)
     nlohmann::json bodyJson;
     bodyJson["jsonrpc"] = "2.0";
     bodyJson["method"]  = method;
@@ -191,7 +181,7 @@ uint64_t Provider::evm_increaseTime(std::chrono::seconds seconds) {
     nlohmann::json params = nlohmann::json::array();
     params.push_back(seconds.count());
 
-    cpr::Response response = makeJsonRpcRequest("evm_increaseTime", params);
+    cpr::Response response = makeJsonRpcRequest("evm_increaseTime", params, connectTimeout);
     if (response.status_code != 200) {
         throw std::runtime_error("Unable to set time");
     }
@@ -205,7 +195,7 @@ uint64_t Provider::evm_increaseTime(std::chrono::seconds seconds) {
     } else if (responseJson["result"].is_null()) {
         throw std::runtime_error("Null result in response");
     }
-    response = makeJsonRpcRequest("evm_mine", nlohmann::json::array());
+    response = makeJsonRpcRequest("evm_mine", nlohmann::json::array(), connectTimeout);
     if (response.status_code != 200) {
         throw std::runtime_error("Unable to set time");
     }

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -22,10 +22,6 @@ Provider::Provider(std::string name, std::string url)
     // Initialize client
 }
 
-Provider::~Provider() {
-    // Cleanup client
-}
-
 void Provider::connectToNetwork() {
     // Here we can verify connection by calling some simple JSON RPC method like `net_version`
     auto response = makeJsonRpcRequest("net_version", cpr::Body("{}"));

--- a/src/signer.cpp
+++ b/src/signer.cpp
@@ -13,14 +13,6 @@
 namespace ethyl
 {
 Signer::Signer() {
-    initContext();
-}
-
-Signer::Signer(const std::shared_ptr<Provider>& _provider) : provider(_provider) {
-    initContext();
-}
-
-void Signer::initContext() {
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     unsigned char randomize[32];
     if (!fill_random(randomize, sizeof(randomize))) {
@@ -134,17 +126,16 @@ std::vector<unsigned char> Signer::sign(std::string_view hash, std::span<const u
 
 void Signer::populateTransaction(Transaction& tx, std::string sender_address) {
     // Check if the signer has a client
-    if (!hasProvider()) {
-        throw std::runtime_error("Signer does not have a provider");
-    }
+    if (provider.clients.empty())
+        throw std::runtime_error("Signer does not have a provider with any RPC backends set. Ensure that the provider has atleast one client");
 
     // If nonce is not set, get it from the network
     if (tx.nonce == 0) {
-        tx.nonce = provider->getTransactionCount(sender_address, "pending");
+        tx.nonce = provider.getTransactionCount(sender_address, "pending");
     }
 
     // Get network's chain ID
-    uint32_t networkChainId = provider->getNetworkChainId();
+    uint32_t networkChainId = provider.getNetworkChainId();
 
     // Check and set chainId
     if (tx.chainId != 0) {
@@ -156,7 +147,7 @@ void Signer::populateTransaction(Transaction& tx, std::string sender_address) {
     }
 
     // Get fee data
-    const auto feeData = provider->getFeeData();
+    const auto feeData = provider.getFeeData();
     tx.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
 
     if (tx.maxFeePerGas == 0) {
@@ -188,7 +179,7 @@ std::string Signer::sendTransaction(Transaction& txn, std::span<const unsigned c
     populateTransaction(txn, senders_address);
     const auto signature_hex = utils::toHexString(sign(txn.hash(), seckey));
     txn.sig.fromHex(signature_hex);
-    const auto hash = provider->sendTransaction(txn);
+    const auto hash = provider.sendTransaction(txn);
     return hash;
 }
 }; // namespace ethyl

--- a/src/signer.cpp
+++ b/src/signer.cpp
@@ -10,6 +10,8 @@
 
 #include <secp256k1_recovery.h>
 
+namespace ethyl
+{
 Signer::Signer() {
     initContext();
 }
@@ -189,3 +191,4 @@ std::string Signer::sendTransaction(Transaction& txn, std::span<const unsigned c
     const auto hash = provider->sendTransaction(txn);
     return hash;
 }
+}; // namespace ethyl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,14 +10,11 @@ foreach(file ${test_sources})
     get_filename_component(test_name ${file} NAME_WE)
     add_executable(${test_name}_tests ${file})
 
-    set(${PROJECT_NAME}_TEST_LIB ${PROJECT_NAME})
-
     target_link_libraries(
       ${test_name}_tests
       PRIVATE
         Catch2::Catch2WithMain
-        ethyl
-        ${${PROJECT_NAME}_TEST_LIB}
+        ${CMAKE_PROJECT_NAME}
         cncrypto
         cpr::cpr
     )

--- a/test/src/basic.cpp
+++ b/test/src/basic.cpp
@@ -22,7 +22,7 @@ unsigned int Factorial( unsigned int number ) {
 
 int add(int a, int b) { return a + b; }
 
-int64_t request() { 
+int64_t request() {
     cpr::Response r = cpr::Get(cpr::Url{"https://api.github.com/repos/whoshuu/cpr/contributors"},
                       cpr::Authentication{"user", "pass", cpr::AuthMode::BASIC},
                       cpr::Parameters{{"anon", "true"}, {"key", "value"}});

--- a/test/src/ethereum_client.cpp
+++ b/test/src/ethereum_client.cpp
@@ -10,13 +10,14 @@
 #include <catch2/catch_all.hpp>
 
 using namespace oxenc::literals;
+using namespace ethyl;
 
 // Construct the client with the local RPC URL
-inline constexpr auto PRIVATE_KEY = "96a656cbd64281ea82257ca9978093b25117592287e4e07f5be660d1701f03e9"_hex_u;
-inline constexpr std::string_view ADDRESS = "0x2ccb8b65024e4aa9615a8e704dfb11be76674f1f";
+inline constexpr auto PRIVATE_KEY               = "96a656cbd64281ea82257ca9978093b25117592287e4e07f5be660d1701f03e9"_hex_u;
+inline constexpr std::string_view ADDRESS       = "0x2ccb8b65024e4aa9615a8e704dfb11be76674f1f";
 inline constexpr std::string_view ANVIL_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
-inline constexpr auto ANVIL_PRIVATE_KEY = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"_hex_u;
-auto provider = std::make_shared<Provider>("Client", std::string("127.0.0.1:8545"));
+inline constexpr auto ANVIL_PRIVATE_KEY         = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"_hex_u;
+auto provider                                   = std::make_shared<Provider>("Client", std::string("127.0.0.1:8545"));
 Signer signer(provider);
 
 TEST_CASE( "Get balance from sepolia network", "[ethereum]" ) {


### PR DESCRIPTION
This includes all the commits from https://github.com/oxen-io/ethyl/pull/18 as I was integrating with oxen-core@integration which is now on C++20.

Introduce `addClient` which allows adding additional backends for
`ethyl::Provider` to fallback to when there's a connection error. A timeout has
been added that can be configured by setting `connectTimeout` to allow
iterating through failing clients at a configurable rate.