### PR TITLE
Overhaul hex-centric APIs, do calculations in binary and then opt into hex conversion

### DIFF
--- a/include/ethyl/ecdsa_util.h
+++ b/include/ethyl/ecdsa_util.h
@@ -41,7 +41,7 @@
 
 
 /* Returns 1 on success, and 0 on failure. */
-[[maybe_unused]] static int fill_random(unsigned char* data, size_t size) {
+[[maybe_unused]] static int ethyl_fill_random(unsigned char* data, size_t size) {
 #if defined(_WIN32) || defined(__CYGWIN__)
     NTSTATUS res = BCryptGenRandom(NULL, data, (ULONG)size, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
     if (res != STATUS_SUCCESS || size > ULONG_MAX) {
@@ -70,17 +70,8 @@
     return 0;
 }
 
-[[maybe_unused]] static void print_hex(unsigned char* data, size_t size) {
-    size_t i;
-    printf("0x");
-    for (i = 0; i < size; i++) {
-        printf("%02x", data[i]);
-    }
-    printf("\n");
-}
-
 /* Cleanses memory to prevent leaking sensitive info. Won't be optimized out. */
-[[maybe_unused]] static void secure_erase(void *ptr, size_t len) {
+[[maybe_unused]] static void ethyl_secure_erase(void *ptr, size_t len) {
 #if defined(_MSC_VER) || defined(__CYGWIN__)
     /* SecureZeroMemory is guaranteed not to be optimized out by MSVC. */
     SecureZeroMemory(ptr, len);

--- a/include/ethyl/logs.hpp
+++ b/include/ethyl/logs.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <optional>
 
+namespace ethyl
+{
 struct LogEntry {
     std::string address; // Address from which this log originated
     std::vector<std::string> topics; // Array of 0-4 32-byte data of indexed log arguments
@@ -16,3 +18,4 @@ struct LogEntry {
     std::optional<uint32_t> logIndex; // Index of the log in the block (optional)
     bool removed; // True if log was removed due to a chain reorganization
 };
+}  // namespace ethyl

--- a/include/ethyl/signer.hpp
+++ b/include/ethyl/signer.hpp
@@ -1,45 +1,55 @@
 #pragma once
 
-#include <array>
-#include <memory>
+#include "provider.hpp"
+#include "utils.hpp"
+
 #include <span>
 #include <string>
 #include <string_view>
 #include <vector>
-
-#include "provider.hpp"
 
 typedef struct secp256k1_context_struct secp256k1_context; // forward decl
 
 namespace ethyl
 {
 class Signer {
-private:
-    secp256k1_context* ctx;
-
-    uint64_t maxPriorityFeePerGas = 0;
-    uint64_t maxFeePerGas = 0;
-    uint64_t gasPrice = 0;
-
 public:
     Signer();
     ~Signer();
 
     // Returns <Pubkey, Seckey>
     std::pair<std::vector<unsigned char>, std::vector<unsigned char>> generate_key_pair();
-    std::array<unsigned char, 20>                                     secretKeyToAddress(std::span<const unsigned char> seckey);
-    std::string                                                       secretKeyToAddressString(std::span<const unsigned char> seckey);
+    Bytes20     secretKeyToAddress(std::span<const unsigned char> seckey);
+    std::string secretKeyToAddressString(std::span<const unsigned char> seckey);
 
-    std::vector<unsigned char> sign(const std::array<unsigned char, 32>& hash, std::span<const unsigned char> seckey);
-    std::vector<unsigned char> sign(std::string_view hash, std::span<const unsigned char> seckey);
+    /// Sign a 32 byte hash with secp256k1 and return an ECDSA signature in
+    /// compact form of 65 bytes (64 bytes + recovery ID)
+    ECDSACompactSignature sign32(std::span<const unsigned char, 32> bytes, std::span<const unsigned char> seckey);
 
-    // Client usage methods
-    std::vector<unsigned char> signMessage(std::string_view message, std::span<const unsigned char> seckey);
-    std::string signTransaction(Transaction& tx, std::span<const unsigned char> seckey);
+    /// Sign the message by hashing `message` with keccak into 32 bytes and then
+    /// sign the 32 bytes using `seckey` with secp256k1.
+    ECDSACompactSignature signMessage(std::string_view message, std::span<const unsigned char> seckey);
+
+    /// Sign a transaction with the given `seckey`. The transaction is updated
+    /// to store the signature as computed by this function. This function
+    /// returns the the RLP serialised TX.
+    std::vector<unsigned char> signTransaction(Transaction& tx, std::span<const unsigned char> seckey);
+
+    /// See `signTransaction`. This function returns the RLP serialised TX in
+    /// hex without a '0x' prefix.
+    std::string signTransactionAsHex(Transaction& tx, std::span<const unsigned char> seckey);
 
     void populateTransaction(Transaction& tx, std::string sender_address);
+
     std::string sendTransaction(Transaction& tx, std::span<const unsigned char> seckey);
 
     Provider provider;
+
+private:
+    secp256k1_context* ctx;
+    uint64_t maxPriorityFeePerGas = 0;
+    uint64_t maxFeePerGas = 0;
+    uint64_t gasPrice = 0;
+
 };
 }; // namespace ethyl

--- a/include/ethyl/transaction.hpp
+++ b/include/ethyl/transaction.hpp
@@ -30,8 +30,10 @@ public:
 
     // Constructor                                                                                                        
     // (toAddress, value, gasLimit, data)
-    Transaction(std::string to, uint64_t value, uint64_t gasLimit = 21000, std::string data = "")
-        : to{std::move(to)}, value{std::move(value)}, gasLimit{gasLimit}, data{std::move(data)} {}
+    Transaction(std::string to, uint64_t value, uint64_t gasLimit = 21000,
+                std::string data = "")
+        : to{std::move(to)}, value{std::move(value)}, gasLimit{gasLimit},
+          data{std::move(data)} {}
 
     std::string serialized() const;
     std::string hash() const;

--- a/include/ethyl/transaction.hpp
+++ b/include/ethyl/transaction.hpp
@@ -1,42 +1,52 @@
 #pragma once
 
+#include "utils.hpp"
 #include <string>
 #include <vector>
 #include <cstdint>
 
 namespace ethyl
 {
-struct Signature {
+struct Signature
+{
     uint64_t signatureYParity = 0;
-    std::vector<unsigned char> signatureR = {};
-    std::vector<unsigned char> signatureS = {};
+    Bytes32 signatureR;
+    Bytes32 signatureS;
 
     bool isEmpty() const;
-
-    void fromHex(std::string_view hex_str);
+    void set(ECDSACompactSignature const &signature);
 };
 
-class Transaction {
-public:
+struct Transaction
+{
+    Transaction() = default;
+
+    Transaction(std::string to, uint64_t value, uint64_t gasLimit = 21000,
+                std::string data = "");
+
+    /// Serialise the transaction into a RLP serialised payload.
+    std::vector<unsigned char> serialize() const;
+
+    /// See `serialize`. The RLP payload is returned in hex without a '0x'
+    /// prefix.
+    std::string serializeAsHex() const;
+
+    /// Calculate the transaction hash by RLP serializing the contents and
+    /// applying a keccak hash.
+    Bytes32 hash() const;
+
+    /// Calculate the transaction hash by calling `hash` and returning the hex
+    /// representation of the 32 byte hash without a '0x' prefix.
+    std::string hashAsHex() const;
+
     uint64_t chainId = 0;
     uint64_t nonce = 0;
     uint64_t maxPriorityFeePerGas = 0;
     uint64_t maxFeePerGas = 0;
     std::string to;
-    uint64_t value;     
-    uint64_t gasLimit;
+    uint64_t value = 0;
+    uint64_t gasLimit = 0;
     std::string data;
     Signature sig;
-
-    // Constructor                                                                                                        
-    // (toAddress, value, gasLimit, data)
-    Transaction(std::string to, uint64_t value, uint64_t gasLimit = 21000,
-                std::string data = "")
-        : to{std::move(to)}, value{std::move(value)}, gasLimit{gasLimit},
-          data{std::move(data)} {}
-
-    std::string serialized() const;
-    std::string hash() const;
-
 };
 }  // namespace ethyl

--- a/include/ethyl/transaction.hpp
+++ b/include/ethyl/transaction.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <cstdint>
 
+namespace ethyl
+{
 struct Signature {
     uint64_t signatureYParity = 0;
     std::vector<unsigned char> signatureR = {};
@@ -35,3 +37,4 @@ public:
     std::string hash() const;
 
 };
+}  // namespace ethyl

--- a/include/ethyl/transaction.hpp
+++ b/include/ethyl/transaction.hpp
@@ -9,11 +9,10 @@ namespace ethyl
 {
 struct Signature
 {
+    bool init = false;
     uint64_t signatureYParity = 0;
     Bytes32 signatureR;
     Bytes32 signatureS;
-
-    bool isEmpty() const;
     void set(ECDSACompactSignature const &signature);
 };
 

--- a/include/ethyl/utils.hpp
+++ b/include/ethyl/utils.hpp
@@ -15,20 +15,10 @@
 
 namespace utils
 {
-
     enum class PaddingDirection {
         LEFT,
         RIGHT
     };
-
-    template <typename Container>
-    std::string toHexString(const Container& bytes) {
-        std::ostringstream oss;
-        for(const auto byte : bytes) {
-            oss << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(static_cast<unsigned char>(byte));
-        }                                                                                                                     
-        return oss.str();                                                                                                     
-    }
 
     template <typename Container>
     std::string toHexStringBigEndian(const Container& bytes) {
@@ -47,6 +37,7 @@ namespace utils
     template <basic_char Char = unsigned char>
     std::vector<Char> fromHexString(std::string_view hexStr) {
         hexStr = trimPrefix(hexStr, "0x");
+        hexStr = trimPrefix(hexStr, "0X");
 
         if (!oxenc::is_hex(hexStr))
             throw std::invalid_argument{"input string is not hex"};
@@ -102,9 +93,17 @@ namespace utils
         return true;
     }
 
-    std::array<unsigned char, 32> hash(std::string_view in);
+    /// Hashes a hex string into a 32-byte hash using keccak by first converting the hex to bytes.
+    /// The hex string is allowed to start with '0x' and '0X'. Passing bytes to this function will
+    /// throw an `invalid_argument` exception.
+    std::array<unsigned char, 32> hashHex(std::string_view hex);
 
-    std::string getFunctionSignature(const std::string& function);
+    /// Hash the bytes into a 32-byte hash using keccak.
+    std::array<unsigned char, 32> hash_(std::string_view bytes);
+
+    /// Get the function signature for Ethereum contract interaction via an ABI
+    /// call
+    std::string getFunctionSignature(std::string_view function);
 
     std::string trimAddress(const std::string& address);
 

--- a/include/ethyl/utils.hpp
+++ b/include/ethyl/utils.hpp
@@ -13,7 +13,7 @@
 #include <oxenc/common.h>
 #include <oxenc/hex.h>
 
-namespace utils
+namespace ethyl::utils
 {
     enum class PaddingDirection {
         LEFT,
@@ -106,6 +106,4 @@ namespace utils
     std::string getFunctionSignature(std::string_view function);
 
     std::string trimAddress(const std::string& address);
-
-// END
-}
+}  // namespace ethyl::utils

--- a/include/ethyl/utils.hpp
+++ b/include/ethyl/utils.hpp
@@ -6,28 +6,22 @@
 #include <string>
 #include <array>
 #include <vector>
-#include <sstream>
-#include <iomanip>
-#include <ios>
 
 #include <oxenc/common.h>
 #include <oxenc/hex.h>
 
-namespace ethyl::utils
+namespace ethyl
+{
+using ECDSACompactSignature = std::array<unsigned char, 64 + 1 /*recovery id*/>;
+using Bytes20 = std::array<unsigned char, 20>;
+using Bytes32 = std::array<unsigned char, 32>;
+
+namespace utils
 {
     enum class PaddingDirection {
         LEFT,
         RIGHT
     };
-
-    template <typename Container>
-    std::string toHexStringBigEndian(const Container& bytes) {
-        std::ostringstream oss;
-        for(auto it = bytes.rbegin(); it != bytes.rend(); ++it) {
-            oss << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(static_cast<unsigned char>(*it));
-        }
-        return oss.str();
-    }
 
     std::string      decimalToHex(uint64_t decimal, bool prefixed_0x = false);
     std::string_view trimPrefix(std::string_view src, std::string_view prefix);
@@ -66,22 +60,21 @@ namespace ethyl::utils
     extern template std::array<char, 32> fromHexString32Byte<char>(std::string_view);
     extern template std::array<unsigned char, 32> fromHexString32Byte<unsigned char>(std::string_view);
 
+    uint64_t hexStringToU64(std::string_view hexStr);
 
-    uint64_t fromHexStringToUint64(std::string_view hexStr);
+    std::string padToNBytes(std::string_view hexInput, size_t bytes, PaddingDirection direction = PaddingDirection::LEFT);
 
-    std::string padToNBytes(std::string_view hex_input, size_t bytes, PaddingDirection direction = PaddingDirection::LEFT);
-    inline std::string padTo8Bytes(std::string_view hex_input, PaddingDirection direction = PaddingDirection::LEFT) {
-        return padToNBytes(hex_input, 8, direction);
+    inline std::string padTo8Bytes(std::string_view hexInput, PaddingDirection direction = PaddingDirection::LEFT) {
+        return padToNBytes(hexInput, 8, direction);
     }
 
-    inline std::string padTo32Bytes(std::string_view hex_input, PaddingDirection direction = PaddingDirection::LEFT) {
-        return padToNBytes(hex_input, 32, direction);
+    inline std::string padTo32Bytes(std::string_view hexInput, PaddingDirection direction = PaddingDirection::LEFT) {
+        return padToNBytes(hexInput, 32, direction);
     }
 
-
-    /// Parses an integer of some sort from a string, requiring that the entire string be consumed
-    /// during parsing.  Return false if parsing failed, sets `value` and returns true if the entire
-    /// string was consumed.
+    /// Parses an integer of some sort from a string, requiring that the entire
+    /// string be consumed during parsing.  Return false if parsing failed, sets
+    /// `value` and returns true if the entire string was consumed.
     template <typename T>
     bool parseInt(const std::string_view str, T& value, int base = 10) {
         T tmp;
@@ -93,17 +86,26 @@ namespace ethyl::utils
         return true;
     }
 
-    /// Hashes a hex string into a 32-byte hash using keccak by first converting the hex to bytes.
-    /// The hex string is allowed to start with '0x' and '0X'. Passing bytes to this function will
-    /// throw an `invalid_argument` exception.
-    std::array<unsigned char, 32> hashHex(std::string_view hex);
+    /// Hashes a hex string into a 32-byte hash using keccak by first converting
+    /// the hex to bytes. The hex string is allowed to start with '0x' and '0X'.
+    /// Passing bytes to this function will throw an `invalid_argument`
+    /// exception.
+    Bytes32 hashHex(std::string_view hex);
 
     /// Hash the bytes into a 32-byte hash using keccak.
-    std::array<unsigned char, 32> hash_(std::string_view bytes);
+    Bytes32 hashBytesPtr(const void *bytes, size_t size);
+
+    /// See `hashBytesPtr`
+    Bytes32 hashBytes(std::span<const char> bytes);
+
+    /// See `hashBytesPtr`
+    Bytes32 hashBytes(std::span<const unsigned char> bytes);
 
     /// Get the function signature for Ethereum contract interaction via an ABI
     /// call
-    std::string getFunctionSignature(std::string_view function);
+    std::string toEthFunctionSignature(std::string_view function);
 
     std::string trimAddress(const std::string& address);
 }  // namespace ethyl::utils
+};
+

--- a/src/crypto/blake256.c
+++ b/src/crypto/blake256.c
@@ -297,7 +297,7 @@ void hmac_blake256_init(hmac_state* S, const uint8_t* _key, uint64_t keylen) {
     }
     blake256_update(&S->outer, pad, 512);
 
-    secure_erase(keyhash, sizeof(keyhash));
+    ethyl_secure_erase(keyhash, sizeof(keyhash));
 }
 
 // keylen = number of bytes
@@ -327,7 +327,7 @@ void hmac_blake224_init(hmac_state* S, const uint8_t* _key, uint64_t keylen) {
     }
     blake224_update(&S->outer, pad, 512);
 
-    secure_erase(keyhash, sizeof(keyhash));
+    ethyl_secure_erase(keyhash, sizeof(keyhash));
 }
 
 // datalen = number of bits
@@ -347,7 +347,7 @@ void hmac_blake256_final(hmac_state* S, uint8_t* digest) {
     blake256_final(&S->inner, ihash);
     blake256_update(&S->outer, ihash, 256);
     blake256_final(&S->outer, digest);
-    secure_erase(ihash, sizeof(ihash));
+    ethyl_secure_erase(ihash, sizeof(ihash));
 }
 
 void hmac_blake224_final(hmac_state* S, uint8_t* digest) {
@@ -355,7 +355,7 @@ void hmac_blake224_final(hmac_state* S, uint8_t* digest) {
     blake224_final(&S->inner, ihash);
     blake224_update(&S->outer, ihash, 224);
     blake224_final(&S->outer, digest);
-    secure_erase(ihash, sizeof(ihash));
+    ethyl_secure_erase(ihash, sizeof(ihash));
 }
 
 // keylen = number of bytes; inlen = number of bytes

--- a/src/crypto/hmac-keccak.c
+++ b/src/crypto/hmac-keccak.c
@@ -58,7 +58,7 @@ void hmac_keccak_init(hmac_keccak_state* S, const uint8_t* _key, size_t keylen) 
     }
     keccak_update(&S->outer, pad, KECCAK_BLOCKLEN);
 
-    secure_erase(keyhash, HASH_SIZE);
+    ethyl_secure_erase(keyhash, HASH_SIZE);
 }
 
 void hmac_keccak_update(hmac_keccak_state* S, const uint8_t* data, size_t datalen) {
@@ -70,7 +70,7 @@ void hmac_keccak_finish(hmac_keccak_state* S, uint8_t* digest) {
     keccak_finish(&S->inner, ihash);
     keccak_update(&S->outer, ihash, HASH_SIZE);
     keccak_finish(&S->outer, digest);
-    secure_erase(ihash, HASH_SIZE);
+    ethyl_secure_erase(ihash, HASH_SIZE);
 }
 
 void hmac_keccak_hash(

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -402,7 +402,7 @@ std::string Provider::sendTransaction(const Transaction& signedTx) {
 // Create and send a raw transaction returns the hash without checking if it succeeded in getting into the mempool
 std::string Provider::sendUncheckedTransaction(const Transaction& signedTx) {
     nlohmann::json params = nlohmann::json::array();
-    params.push_back(signedTx.serialized());
+    params.push_back(signedTx.serializeAsHex());
     
     auto response = makeJsonRpcRequest("eth_sendRawTransaction", params, connectTimeout);
     if (response.status_code == 200) {
@@ -428,7 +428,7 @@ uint64_t Provider::waitForTransaction(
 
                     // Parse the block number from the hex string
                     auto blockNumberHex = (*maybe_tx_json)["blockNumber"].get<std::string_view>();
-                    return utils::fromHexStringToUint64(blockNumberHex);
+                    return utils::hexStringToU64(blockNumberHex);
                 }
                 return std::nullopt;
             },
@@ -443,7 +443,7 @@ bool Provider::transactionSuccessful(std::string_view txHash, std::chrono::milli
 
                     // Parse the status from the hex string
                     auto statusHex = (*maybe_tx_json)["status"].get<std::string_view>();
-                    return static_cast<bool>(utils::fromHexStringToUint64(statusHex));
+                    return static_cast<bool>(utils::hexStringToU64(statusHex));
                 }
                 return std::nullopt;
             },
@@ -458,7 +458,7 @@ uint64_t Provider::gasUsed(std::string_view txHash, std::chrono::milliseconds ti
 
                     // Parse the status from the hex string
                     auto gasUsed = (*maybe_tx_json)["gasUsed"].get<std::string_view>();
-                    return utils::fromHexStringToUint64(gasUsed);
+                    return utils::hexStringToU64(gasUsed);
                 }
                 return std::nullopt;
             },

--- a/src/provider.cpp
+++ b/src/provider.cpp
@@ -402,7 +402,7 @@ std::string Provider::sendTransaction(const Transaction& signedTx) {
 // Create and send a raw transaction returns the hash without checking if it succeeded in getting into the mempool
 std::string Provider::sendUncheckedTransaction(const Transaction& signedTx) {
     nlohmann::json params = nlohmann::json::array();
-    params.push_back(signedTx.serializeAsHex());
+    params.push_back("0x" + signedTx.serializeAsHex());
     
     auto response = makeJsonRpcRequest("eth_sendRawTransaction", params, connectTimeout);
     if (response.status_code == 200) {

--- a/src/signer.cpp
+++ b/src/signer.cpp
@@ -15,7 +15,7 @@ namespace ethyl
 Signer::Signer() {
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     unsigned char randomize[32];
-    if (!fill_random(randomize, sizeof(randomize))) {
+    if (!ethyl_fill_random(randomize, sizeof(randomize))) {
         throw std::runtime_error("Failed to generate randomness");
     }
     if (!secp256k1_context_randomize(ctx, randomize))
@@ -33,7 +33,7 @@ std::pair<std::vector<unsigned char>, std::vector<unsigned char>> Signer::genera
     secp256k1_pubkey pubkey;
 
     while (1) {
-        if (!fill_random(seckey, sizeof(seckey))) {
+        if (!ethyl_fill_random(seckey, sizeof(seckey))) {
             throw std::runtime_error("Failed to generate randomness");
         }
         if (secp256k1_ec_seckey_verify(ctx, seckey)) {

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -39,7 +39,7 @@ std::string Transaction::serialized() const {
 }
 
 std::string Transaction::hash() const {
-    std::array<unsigned char, 32> hash = utils::hash_(serialized());
+    std::array<unsigned char, 32> hash = utils::hashHex(serialized());
     std::string result = "0x" + oxenc::to_hex(hash.begin(), hash.end());
     return result;
 }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1,10 +1,14 @@
 #include "ethyl/transaction.hpp"
-#include "ethyl/utils.hpp"
 
 #include <oxenc/rlp_serialize.h>
 
 namespace ethyl
 {
+Transaction::Transaction(std::string to, uint64_t value, uint64_t gasLimit,
+                         std::string data)
+    : to{std::move(to)}, value{std::move(value)}, gasLimit{gasLimit},
+      data{std::move(data)} {}
+
 /**
 * Returns the raw Bytes of the EIP-1559 transaction, in order.
 *
@@ -14,7 +18,7 @@ namespace ethyl
 * For an unsigned tx this method uses the empty Bytes values for the
 * signature parameters `v`, `r` and `s` for encoding.
 */
-std::string Transaction::serialized() const {
+std::vector<unsigned char> Transaction::serialize() const {
     using namespace oxenc;
 
     std::vector<std::variant<uint64_t, std::span<const unsigned char>, std::vector<unsigned char>, std::vector<uint64_t>>> arr;
@@ -35,30 +39,44 @@ std::string Transaction::serialized() const {
         arr.push_back(oxenc::rlp_big_integer(sig.signatureR));
         arr.push_back(oxenc::rlp_big_integer(sig.signatureS));
     }
-    return "0x02" + oxenc::to_hex(rlp_serialize(arr));
+
+    std::string serializedBytes = rlp_serialize(arr);
+    std::vector<unsigned char> result;
+    result.reserve(1 /*header*/ + serializedBytes.size());
+    result.push_back(0x02);
+    result.insert(result.end(), serializedBytes.begin(), serializedBytes.end());
+    return result;
 }
 
-std::string Transaction::hash() const {
-    std::array<unsigned char, 32> hash = utils::hashHex(serialized());
-    std::string result = "0x" + oxenc::to_hex(hash.begin(), hash.end());
+std::string Transaction::serializeAsHex() const {
+    std::vector<unsigned char> serializedBytes = serialize();
+    std::string result = oxenc::to_hex(serializedBytes.begin(), serializedBytes.end());
+    return result;
+}
+
+Bytes32 Transaction::hash() const {
+    std::vector<unsigned char> serializedBytes = serialize();
+    Bytes32 result = utils::hashBytes(serializedBytes);
+    return result;
+}
+
+std::string Transaction::hashAsHex() const {
+    Bytes32 txHash = hash();
+    std::string result = oxenc::to_hex(txHash.begin(), txHash.end());
     return result;
 }
 
 bool Signature::isEmpty() const {
-    return signatureYParity == 0 && signatureR.empty() && signatureS.empty();
+  static constexpr Bytes32 zero = {};
+  bool result =
+      signatureYParity == 0 && signatureR == zero && signatureS == zero;
+  return result;
 }
 
-void Signature::fromHex(std::string_view hex_str) {
-
-    auto bytes = utils::fromHexString(hex_str);
-    if (bytes.size() != 65) {
-        throw std::invalid_argument("Input string length should be 130 characters for 65 bytes");
-    }
-
-    signatureR.resize(32);
-    signatureS.resize(32);
-    std::memcpy(signatureR.data(), bytes.data(), 32);
-    std::memcpy(signatureS.data(), bytes.data() + 32, 32);
-    signatureYParity = bytes[64];
+void Signature::set(const ECDSACompactSignature& signature) {
+    assert(signature.max_size() == 65);
+    std::memcpy(signatureR.data(), &signature[0],  32);
+    std::memcpy(signatureS.data(), &signature[32], 32);
+    signatureYParity = static_cast<unsigned char>(signature[signature.max_size() - 1]);
 }
 }  // namespace ethyl

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -3,6 +3,8 @@
 
 #include <oxenc/rlp_serialize.h>
 
+namespace ethyl
+{
 /**
 * Returns the raw Bytes of the EIP-1559 transaction, in order.
 *
@@ -59,3 +61,4 @@ void Signature::fromHex(std::string_view hex_str) {
     std::memcpy(signatureS.data(), bytes.data() + 32, 32);
     signatureYParity = bytes[64];
 }
+}  // namespace ethyl

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -34,7 +34,7 @@ std::vector<unsigned char> Transaction::serialize() const {
     // Access list not going to use
     arr.push_back(std::vector<uint64_t>{});
 
-    if (!sig.isEmpty()) {
+    if (sig.init) {
         arr.push_back(sig.signatureYParity);
         arr.push_back(oxenc::rlp_big_integer(sig.signatureR));
         arr.push_back(oxenc::rlp_big_integer(sig.signatureS));
@@ -66,17 +66,11 @@ std::string Transaction::hashAsHex() const {
     return result;
 }
 
-bool Signature::isEmpty() const {
-  static constexpr Bytes32 zero = {};
-  bool result =
-      signatureYParity == 0 && signatureR == zero && signatureS == zero;
-  return result;
-}
-
 void Signature::set(const ECDSACompactSignature& signature) {
     assert(signature.max_size() == 65);
     std::memcpy(signatureR.data(), &signature[0],  32);
     std::memcpy(signatureS.data(), &signature[32], 32);
     signatureYParity = static_cast<unsigned char>(signature[signature.max_size() - 1]);
+    init = true;
 }
 }  // namespace ethyl

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -37,7 +37,9 @@ std::string Transaction::serialized() const {
 }
 
 std::string Transaction::hash() const {
-    return "0x" + utils::toHexString(utils::hash(serialized()));
+    std::array<unsigned char, 32> hash = utils::hash_(serialized());
+    std::string result = "0x" + oxenc::to_hex(hash.begin(), hash.end());
+    return result;
 }
 
 bool Signature::isEmpty() const {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -38,11 +38,15 @@ std::string_view utils::trimLeadingZeros(std::string_view src) {
 }
 
 uint64_t utils::hexStringToU64(std::string_view hexStr) {
+    hexStr = trimPrefix(hexStr, "0x");
+    hexStr = trimPrefix(hexStr, "0X");
+    hexStr = trimLeadingZeros(hexStr);
+
     uint64_t val;
-    if (parseInt(trimPrefix(hexStr, "0x"), val, 16))
+    if (parseInt(hexStr, val, 16))
         return val;
 
-    throw std::invalid_argument{"failed to parse integer from hex input"};
+    throw std::invalid_argument{"failed to parse integer from hex input: " + std::string(hexStr)};
 }
 
 template std::vector<char> utils::fromHexString<char>(std::string_view);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,6 +12,8 @@ extern "C" {
 #include "crypto/keccak.h"
 }
 
+namespace ethyl
+{
 std::string utils::decimalToHex(uint64_t decimal, bool prefixed_0x) {
     char buf[22];
     if (prefixed_0x) {
@@ -113,3 +115,4 @@ std::string utils::trimAddress(const std::string& address) {
     // Trim and return the address
     return "0x" + address.substr(firstNonZero, 40);
 }
+};  // namespace ethyl

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -48,28 +48,24 @@ template std::vector<unsigned char> utils::fromHexString<unsigned char>(std::str
 template std::array<char, 32> utils::fromHexString32Byte<char>(std::string_view);
 template std::array<unsigned char, 32> utils::fromHexString32Byte<unsigned char>(std::string_view);
 
-std::array<unsigned char, 32> utils::hash(std::string_view in) {
-    std::vector<char> bytes;
+std::array<unsigned char, 32> utils::hashHex(std::string_view hex) {
+    std::vector<char> bytes = fromHexString<char>(hex);
+    std::array<unsigned char, 32> result =
+            utils::hash_(std::string_view(bytes.data(), bytes.size()));
+    return result;
+}
 
-    // Check for "0x" prefix and if exists, convert the hex to bytes
-    if (in.starts_with("0x")) {
-        bytes = fromHexString<char>(in);
-        in = {bytes.data(), bytes.size()};
-    }
+std::array<unsigned char, 32> utils::hash_(std::string_view bytes) {
     std::array<unsigned char, 32> hash;
-    keccak(reinterpret_cast<const uint8_t*>(in.data()), in.size(), hash.data(), 32);
+    keccak(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), hash.data(), 32);
     return hash;
 }
 
-// Function to get the function signature for Ethereum contract interaction
-std::string utils::getFunctionSignature(const std::string& function) {
-    std::array<unsigned char, 32> hash = utils::hash(function);
-
-    // Convert the hash to hex string
-    std::string hashHex = toHexString(hash);
-
-    // Return the first 8 characters of the hex string (4 bytes) plus 0x prefix
-    return "0x" + hashHex.substr(0, 8);
+std::string utils::getFunctionSignature(std::string_view function) {
+    std::array<unsigned char, 32> hash = utils::hash_(function);
+    std::string hashHex = oxenc::to_hex(hash.begin(), hash.end());
+    std::string result = "0x" + hashHex.substr(0, 8); // Return the first 8 characters of the hex string (4 bytes) plus 0x prefix
+    return result;
 }
 
 std::string utils::padToNBytes(

--- a/test/src/basic.cpp
+++ b/test/src/basic.cpp
@@ -52,7 +52,7 @@ int ecdsa() {
     secp256k1_ecdsa_signature sig;
     /* Before we can call actual API functions, we need to create a "context". */
     secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
-    if (!fill_random(randomize, sizeof(randomize))) {
+    if (!ethyl_fill_random(randomize, sizeof(randomize))) {
         printf("Failed to generate randomness\n");
         return 1;
     }
@@ -68,7 +68,7 @@ int ecdsa() {
      * order), we try to sample a new key. Note that the probability of this
      * happening is negligible. */
     while (1) {
-        if (!fill_random(seckey, sizeof(seckey))) {
+        if (!ethyl_fill_random(seckey, sizeof(seckey))) {
             printf("Failed to generate randomness\n");
             return 1;
         }
@@ -147,7 +147,7 @@ int ecdsa() {
      *
      * Here we are preventing these writes from being optimized out, as any good compiler
      * will remove any writes that aren't used. */
-    secure_erase(seckey, sizeof(seckey));
+    ethyl_secure_erase(seckey, sizeof(seckey));
 
     return 0;
 }

--- a/test/src/basic.cpp
+++ b/test/src/basic.cpp
@@ -12,6 +12,7 @@
 #include <secp256k1.h>
 
 #include "ethyl/ecdsa_util.h"
+#include <oxenc/hex.h>
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_all.hpp>
@@ -120,13 +121,14 @@ int ecdsa() {
     /* Verify a signature. This will return 1 if it's valid and 0 if it's not. */
     is_signature_valid = secp256k1_ecdsa_verify(ctx, &sig, msg_hash, &pubkey);
 
+    std::string seckey_hex = oxenc::to_hex(std::begin(seckey), std::end(seckey));
+    std::string compressed_pubkey_hex = oxenc::to_hex(std::begin(compressed_pubkey), std::end(compressed_pubkey));
+    std::string serialized_signature_hex = oxenc::to_hex(std::begin(serialized_signature), std::end(serialized_signature));
+
     printf("Is the signature valid? %s\n", is_signature_valid ? "true" : "false");
-    printf("Secret Key: ");
-    print_hex(seckey, sizeof(seckey));
-    printf("Public Key: ");
-    print_hex(compressed_pubkey, sizeof(compressed_pubkey));
-    printf("Signature: ");
-    print_hex(serialized_signature, sizeof(serialized_signature));
+    printf("Secret Key: %s\n", seckey_hex.c_str());
+    printf("Public Key: %s\n", compressed_pubkey_hex.c_str());
+    printf("Signature: %s\n", serialized_signature_hex.c_str());
 
     /* This will clear everything from the context and free the memory */
     secp256k1_context_destroy(ctx);

--- a/test/src/ethereum_client.cpp
+++ b/test/src/ethereum_client.cpp
@@ -36,13 +36,14 @@ TEST_CASE( "Get balance from sepolia network", "[ethereum]" ) {
 }
 
 TEST_CASE( "HashTest", "[utils]" ) {
-    std::array<unsigned char, 32> hash = utils::hash_("hello world!");
+    std::string_view text = "hello world!";
+    Bytes32 hash = utils::hashBytes(std::span(text.data(), text.size()));
     std::string hash_hello_world = oxenc::to_hex(hash.begin(), hash.end());
     REQUIRE( hash_hello_world == "57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6" );
 }
 
 TEST_CASE( "SigningTest", "[signer]" ) {
-    std::array<unsigned char, 32> hash =utils::hash_("Hello World!\n");
+    Bytes32 hash = utils::hashBytes("Hello World!\n");
     std::string hash_hello_world = oxenc::to_hex(hash.begin(), hash.end());
     const auto signature_bytes = signer.signMessage("Hello World!", PRIVATE_KEY);
     std::string signature_hex = oxenc::to_hex(signature_bytes.begin(), signature_bytes.end());
@@ -74,8 +75,8 @@ TEST_CASE( "Serialise a raw transaction correctly", "[transaction]" ) {
     Transaction tx("0xA6C077fd9283421C657EcEa8a9c1422cc6CEbc80", 1000000000000000000, 21000);
     tx.nonce = 1;
     tx.chainId = 1;
-    std::string raw_tx = tx.serialized();
-    std::string correct_raw_tx = "0x02e70101808082520894a6c077fd9283421c657ecea8a9c1422cc6cebc80880de0b6b3a764000080c0";
+    std::string raw_tx = tx.serializeAsHex();
+    std::string correct_raw_tx = "02e70101808082520894a6c077fd9283421c657ecea8a9c1422cc6cebc80880de0b6b3a764000080c0";
     REQUIRE(raw_tx == correct_raw_tx);
 }
 
@@ -83,8 +84,8 @@ TEST_CASE( "Hashes an unsigned transaction correctly", "[transaction]" ) {
     Transaction tx("0xA6C077fd9283421C657EcEa8a9c1422cc6CEbc80", 1000000000000000000, 21000);
     tx.nonce = 1;
     tx.chainId = 1;
-    std::string unsigned_hash = tx.hash();
-    std::string correct_hash = "0xf81a17092cfb066efa3ff6ef92016adc06ff66a64327359c4003d215d56128b3";
+    std::string unsigned_hash = tx.hashAsHex();
+    std::string correct_hash = "f81a17092cfb066efa3ff6ef92016adc06ff66a64327359c4003d215d56128b3";
     REQUIRE(unsigned_hash == correct_hash);
 }
 
@@ -92,8 +93,8 @@ TEST_CASE( "Signs an unsigned transaction correctly", "[transaction]" ) {
     Transaction tx("0xA6C077fd9283421C657EcEa8a9c1422cc6CEbc80", 1000000000000000000, 21000);
     tx.nonce = 1;
     tx.chainId = 1;
-    const auto signature_hex_string = signer.signTransaction(tx, PRIVATE_KEY);
-    REQUIRE( signature_hex_string == "0x02f86a0101808082520894a6c077fd9283421c657ecea8a9c1422cc6cebc80880de0b6b3a764000080c080a084987299f8dd115333356ab03430ca8de593e03ba03d4ecd72daf15205119cf8a0216c9869da3497ae96dcb98713908af1a0abf866c12d51def821caf0374cccbb" );
+    const auto signature_hex_string = signer.signTransactionAsHex(tx, PRIVATE_KEY);
+    REQUIRE(signature_hex_string == "02f86a0101808082520894a6c077fd9283421c657ecea8a9c1422cc6cebc80880de0b6b3a764000080c080a084987299f8dd115333356ab03430ca8de593e03ba03d4ecd72daf15205119cf8a0216c9869da3497ae96dcb98713908af1a0abf866c12d51def821caf0374cccbb" );
 }
 
 TEST_CASE( "Does a self transfer", "[transaction]" ) {

--- a/test/src/ethereum_client.cpp
+++ b/test/src/ethereum_client.cpp
@@ -36,14 +36,16 @@ TEST_CASE( "Get balance from sepolia network", "[ethereum]" ) {
 }
 
 TEST_CASE( "HashTest", "[utils]" ) {
-    std::string hash_hello_world = utils::toHexString(utils::hash("hello world!"));
+    std::array<unsigned char, 32> hash = utils::hash_("hello world!");
+    std::string hash_hello_world = oxenc::to_hex(hash.begin(), hash.end());
     REQUIRE( hash_hello_world == "57caa176af1ac0433c5df30e8dabcd2ec1af1e92a26eced5f719b88458777cd6" );
 }
 
 TEST_CASE( "SigningTest", "[signer]" ) {
-    std::string hash_hello_world = utils::toHexString(utils::hash("Hello World!\n"));
+    std::array<unsigned char, 32> hash =utils::hash_("Hello World!\n");
+    std::string hash_hello_world = oxenc::to_hex(hash.begin(), hash.end());
     const auto signature_bytes = signer.signMessage("Hello World!", PRIVATE_KEY);
-    std::string signature_hex = utils::toHexString(signature_bytes);
+    std::string signature_hex = oxenc::to_hex(signature_bytes.begin(), signature_bytes.end());
     REQUIRE( signature_hex == "35f409302082e02b5126c82be93a3946d30e93722ce3ff87bdb01fc385fe312054f3fade7fab80dcabadabf96af75577327dfd064abd47a36543a475e04840e701" );
 }
 


### PR DESCRIPTION
- Fix `utils::hash` automatically converting streams into hex causing erroneous behaviour when a binary streams starts with the bytes '0x'. We have `utils::hashHex` which converts the hex to binary before hashing and a `utils::hashBytes` which hashes the byte stream directly.
- Namespace all the remaining files with `ethyl` including `ecdsa_util.h`. For the C header I've opted to just namespace the functions with `ethyl_`, e.g. `ethyl_fill_random` and so forth to be compatible with C source code.
- Overhaul a bunch of the APIs to be allocation free where possible

```
Previous iteration of the API favoured returning hex from the interface
and working with a bunch of hex strings. What this leads to is

- Extra unneeded computation. Pretty much all libraries work with
binary data which meant a round-trip hex conversion everytime we produced data.

- String validation code is present everywhere. We have to ensure that
all the characters are hex and if they start with '0x' or even '0X' we
trim those out. This is a lot of extra work that is avoided by working
in binary.

I've relegated most of the dynamic containers to those that need
dynanism (like serializing a transaction to RLP since we have variable
data payloads). Everything else, especially hashes and cryptography are
now represented with fixed byte buffers.

All APIs generate binary data first, _then_ there're helper functions
that convert the binary to hex if hex is needed (e.g. serialising to JSON).
```