### PR TITLE
Update cpr to our own fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/catchorg/Catch2.git
 [submodule "external/cpr"]
 	path = external/cpr
-	url = https://github.com/libcpr/cpr.git
+	url = https://github.com/oxen-io/cpr.git
 [submodule "external/secp256k1"]
 	path = external/secp256k1
 	url = https://github.com/bitcoin-core/secp256k1.git


### PR DESCRIPTION
- Updates to latest stable cpr
- Fixes an upstream bug that forces flags into CMAKE_CXX_FLAGS even when used as a dependency.