### PR TITLE
Replace gmpxx usage with gmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,7 @@ target_link_libraries(
   PRIVATE
     cpr::cpr
     oxen::logging
-    gmp
-    gmpxx
+    gmp::gmp
 )
 if(${PROJECT_NAME}_ENABLE_SIGNER)
     target_link_libraries(${PROJECT_NAME} PUBLIC secp256k1)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -62,7 +62,8 @@ endif()
 # GMP
 #
 
-pkg_check_modules(GMP gmp IMPORTED_TARGET REQUIRED)
-add_library(gmp INTERFACE)
-target_link_libraries(gmp INTERFACE PkgConfig::GMP)
-message(STATUS "Found gmp ${GMP_VERSION}")
+if(NOT TARGET gmp::gmp)
+    pkg_check_modules(GMP gmp IMPORTED_TARGET REQUIRED GLOBAL)
+    add_library(gmp::gmp ALIAS PkgConfig::GMP)
+    message(STATUS "Found gmp ${GMP_VERSION}")
+endif()


### PR DESCRIPTION
The packaging isn't looking for gmpxx, and so fails when gmp is installed but gmpxx isn't.  Rather than add a dependency on both gmpxx and gmp, this just replaces the small amount of gmpxx usage with gmp and drops the gmpxx linking.

Also fixes cmake target names to be less error prone (using gmp::gmp rather than bare gmp or gmpxx ensures cmake sees a missing target rather than it failing later at build time), and to not do anything if a gmp::gmp target is already available (e.g. from a parent project).